### PR TITLE
Add image deletion and project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Eframe
+
+A simple Flask application for uploading, previewing, rotating, and displaying images on an e-paper panel. Images are stored locally and can be sent to the display with letterbox or crop modes.
+
+## Requirements
+
+- Python 3.10+
+- Dependencies from `requirements.txt`
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the server:
+   ```bash
+   python app.py
+   ```
+3. Open the web UI at `http://localhost:5000`.
+
+## Usage
+
+- **Upload**: Choose an image file (png, jpg, jpeg, gif, bmp, webp) and optionally send it to the display immediately.
+- **Display**: Send any saved image to the e-paper panel using letterbox or crop modes.
+- **Rotate**: Rotate saved images left or right before displaying.
+- **Preview**: Thumbnails in the gallery load directly from stored files.
+- **Delete**: Remove an uploaded image from storage using the delete button on each card.
+
+Uploaded files are stored in the `uploads/` directory. The app attempts to use the e-paper driver if available; otherwise it runs in development mode without display output.

--- a/app.py
+++ b/app.py
@@ -222,6 +222,21 @@ def preview(filename):
     return send_from_directory(str(UPLOAD_DIR), path.name)
 
 
+@app.route('/delete/<filename>', methods=['POST'])
+def delete(filename):
+    path = get_image_path(filename)
+    if not path:
+        abort(404)
+
+    try:
+        path.unlink()
+    except OSError as exc:
+        logger.error(f"Failed to delete {path}: {exc}")
+        abort(500)
+
+    return redirect(url_for('index'))
+
+
 @app.route('/upload_image')
 def upload_page():
     return redirect(url_for('index'))

--- a/templates/index.html
+++ b/templates/index.html
@@ -91,6 +91,9 @@
                                                 <button class="btn btn-outline-secondary" type="submit">⟳ Rotate right</button>
                                             </form>
                                         </div>
+                                        <form action="/delete/{{ file.name }}" method="POST" onsubmit="return confirm('Delete this image?')">
+                                            <button class="btn btn-outline-danger w-100" type="submit">Delete image</button>
+                                        </form>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- add Flask endpoint to delete uploaded images securely
- include delete controls in the gallery UI
- document setup and usage in a new README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694cdbc7d4008329a2555a99b164f247)