### PR TITLE
Add flip-only image correction control

### DIFF
--- a/app.py
+++ b/app.py
@@ -160,11 +160,11 @@ def get_uploaded_files(limit: int = 24):
     return files[:limit]
 
 
-def rotate_image_file(path: Path, degrees: int) -> None:
+def flip_image_file(path: Path) -> None:
     img = Image.open(path)
     img = ImageOps.exif_transpose(img)
-    rotated = img.rotate(degrees, expand=True)
-    rotated.save(path)
+    flipped = img.rotate(180, expand=True)
+    flipped.save(path)
 
 
 # --- ROUTES ---
@@ -202,15 +202,13 @@ def display(filename):
     return redirect(url_for('index'))
 
 
-@app.route('/rotate/<filename>', methods=['POST'])
-def rotate(filename):
+@app.route('/flip/<filename>', methods=['POST'])
+def flip(filename):
     path = get_image_path(filename)
     if not path:
         abort(404)
 
-    direction = request.form.get('direction', 'right')
-    degrees = -90 if direction == 'left' else 90
-    rotate_image_file(path, degrees)
+    flip_image_file(path)
     return redirect(url_for('index'))
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
             <div class="d-flex align-items-center justify-content-between mb-3">
                 <div>
                     <h3 class="mb-0">E-Ink Image Controller</h3>
-                    <small class="text-muted">Upload, rotate, and send saved images to your display.</small>
+                    <small class="text-muted">Upload, flip, and send saved images to your display.</small>
                 </div>
                 <a href="/" class="btn btn-outline-secondary">Refresh</a>
             </div>
@@ -81,16 +81,9 @@
                                                 <button class="btn btn-outline-primary" type="submit">Display (Crop)</button>
                                             </form>
                                         </div>
-                                        <div class="btn-group" role="group">
-                                            <form action="/rotate/{{ file.name }}" method="POST">
-                                                <input type="hidden" name="direction" value="left">
-                                                <button class="btn btn-outline-secondary" type="submit">⟲ Rotate left</button>
-                                            </form>
-                                            <form action="/rotate/{{ file.name }}" method="POST">
-                                                <input type="hidden" name="direction" value="right">
-                                                <button class="btn btn-outline-secondary" type="submit">⟳ Rotate right</button>
-                                            </form>
-                                        </div>
+                                        <form action="/flip/{{ file.name }}" method="POST">
+                                            <button class="btn btn-outline-secondary w-100" type="submit">Flip 180°</button>
+                                        </form>
                                         <form action="/delete/{{ file.name }}" method="POST" onsubmit="return confirm('Delete this image?')">
                                             <button class="btn btn-outline-danger w-100" type="submit">Delete image</button>
                                         </form>


### PR DESCRIPTION
## Summary
- replace the rotate endpoints/buttons with a single 180-degree flip action for saved images
- update the backend to flip image files 180° instead of rotating left/right
- refresh UI copy to reflect the flip-focused controls

## Testing
- python -m py_compile app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694cdc5f967483299054e0a9532e4d8b)